### PR TITLE
modify sequence table operation

### DIFF
--- a/data_store_service_client.cpp
+++ b/data_store_service_client.cpp
@@ -922,45 +922,6 @@ bool DataStoreServiceClient::DeleteOutOfRangeData(
     return true;
 }
 
-// TODO(lzx): remove this function from DataStoreHandler after updating
-// other store_handler (fetch range partition id from sequences table).
-bool DataStoreServiceClient::GetNextRangePartitionId(
-    const txservice::TableName &tablename,
-    const txservice::TableSchema *table_schema,
-    uint32_t range_cnt,
-    int32_t &out_next_partition_id,
-    int retry_count)
-{
-    int64_t reserved_cnt;
-    uint64_t key_schema_ts;
-    if (tablename.IsBase())
-    {
-        key_schema_ts = table_schema->KeySchema()->SchemaTs();
-    }
-    else
-    {
-        key_schema_ts = table_schema->IndexKeySchema(tablename)->SchemaTs();
-    }
-
-    int64_t first_reserved_id = -1;
-    bool res = txservice::Sequences::ApplyIdOfTableRangePartition(
-        tablename, range_cnt, first_reserved_id, reserved_cnt, key_schema_ts);
-
-    if (!res)
-    {
-        LOG(ERROR) << "GetNextRangePartitionId failed for not assigned "
-                      "enough range ids, first_reserved_id:"
-                   << first_reserved_id << ", reserved_cnt: " << reserved_cnt;
-        return false;
-    }
-    assert(reserved_cnt == range_cnt);
-
-    assert(first_reserved_id + reserved_cnt < INT32_MAX);
-
-    out_next_partition_id = static_cast<int32_t>(first_reserved_id);
-    return true;
-}
-
 bool DataStoreServiceClient::Read(const txservice::TableName &table_name,
                                   const txservice::TxKey &key,
                                   txservice::TxRecord &rec,

--- a/data_store_service_client.h
+++ b/data_store_service_client.h
@@ -180,12 +180,6 @@ public:
         const txservice::TxKey *start_key,
         const txservice::TableSchema *table_schema) override;
 
-    bool GetNextRangePartitionId(const txservice::TableName &tablename,
-                                 const txservice::TableSchema *table_schema,
-                                 uint32_t range_cnt,
-                                 int32_t &out_next_partition_id,
-                                 int retry_count) override;
-
     bool Read(const txservice::TableName &table_name,
               const txservice::TxKey &key,
               txservice::TxRecord &rec,

--- a/data_store_service_client.h
+++ b/data_store_service_client.h
@@ -531,11 +531,6 @@ private:
 
     bool InitTableLastRangePartitionId(const txservice::TableName &table_name);
 
-    bool DeleteTableLastRangePartitionId(
-        const txservice::TableName &table_name);
-
-    bool DeleteSequence(const txservice::TableName &base_table_name);
-
     bool DeleteTableStatistics(const txservice::TableName &base_table_name);
 
     // Caculate kv partition id of records in System table(catalogs, ranges,
@@ -565,13 +560,6 @@ private:
 #else
         return key_partition;
 #endif
-    }
-
-    int32_t InitialRangePartitionIdOf(const txservice::TableName &table) const
-    {
-        assert(table.Engine() != txservice::TableEngine::EloqKv);
-        std::string_view sv = table.StringView();
-        return (std::hash<std::string_view>()(sv)) & 0xFFF;
     }
 
     /**


### PR DESCRIPTION
Currently, the sequence table stores two types of information:
    1. The latest range ID for each table.
    2. The auto-increment column values for tables that have such columns.

    This table is managed by the `txservice::Sequence` class.
    For DDL operations, it is necessary to update the corresponding range ID and auto-increment value (if the table has an auto-increment column).
    Therefore, the operations on the sequence table are implemented as a sub-operation of `UpsertTableOp` and `UpsertTableIndexOp`.

    The following DDL statements require updating the range ID in the sequence table:
    `CREATE / DROP / TRUNCATE TABLE, ADD / DROP INDEX`

    The following DDL statements require updating the auto-increment value (if the table has an auto-increment column):
    `CREATE / DROP / TRUNCATE TABLE`