### PR TITLE
feat: config eloqstore cloud store

### DIFF
--- a/eloq_data_store_service/eloq_store_data_store.h
+++ b/eloq_data_store_service/eloq_store_data_store.h
@@ -164,6 +164,8 @@ struct EloqStoreConfig
     uint16_t worker_count_{1};
     std::string storage_path_{""};
     uint32_t open_files_limit_{1024};
+    std::string cloud_store_path_{""};
+    uint16_t gc_threads_{1};
 };
 
 class EloqStoreDataStore : public DataStore

--- a/eloq_data_store_service/eloq_store_data_store_factory.h
+++ b/eloq_data_store_service/eloq_store_data_store_factory.h
@@ -50,11 +50,21 @@ public:
             .append("/ds_")
             .append(std::to_string(shard_id));
         store_config.fd_limit = eloq_store_configs_.open_files_limit_;
+        if (!eloq_store_configs_.cloud_store_path_.empty())
+        {
+            store_config.cloud_store_path
+                .append(eloq_store_configs_.cloud_store_path_)
+                .append("/ds_")
+                .append(std::to_string(shard_id));
+        }
+        store_config.num_gc_threads = eloq_store_configs_.gc_threads_;
 
         DLOG(INFO) << "Create EloqStore storage with workers: "
                    << store_config.num_threads
                    << ", store path: " << store_config.store_path.front()
-                   << ", open files limit: " << store_config.fd_limit;
+                   << ", open files limit: " << store_config.fd_limit
+                   << ", cloud store path: " << store_config.cloud_store_path
+                   << ", gc threads: " << store_config.num_gc_threads;
         auto ds = std::make_unique<EloqStoreDataStore>(
             shard_id, data_store_service, store_config);
         ds->Initialize();

--- a/eloq_data_store_service/main.cpp
+++ b/eloq_data_store_service/main.cpp
@@ -93,6 +93,13 @@ DEFINE_string(eloq_store_data_path,
 DEFINE_uint32(eloq_store_open_files_limit,
               1024,
               "EloqStore maximum open files.");
+DEFINE_string(eloq_store_cloud_store_path,
+              "",
+              "EloqStore cloud store path (disable cloud store if empty)");
+DEFINE_uint32(
+    eloq_store_gc_threads,
+    1,
+    "EloqStore gc threads count (Must be 0 when cloud store is enabled).");
 #endif
 
 static bool CheckCommandLineFlagIsDefault(const char *name)
@@ -333,6 +340,23 @@ int main(int argc, char *argv[])
             : config_reader.GetInteger("store",
                                        "eloq_store_open_files_limit",
                                        FLAGS_eloq_store_open_files_limit);
+
+    eloq_store_config.cloud_store_path_ =
+        !CheckCommandLineFlagIsDefault("eloq_store_cloud_store_path")
+            ? FLAGS_eloq_store_cloud_store_path
+            : config_reader.GetString("store",
+                                      "eloq_store_cloud_store_path",
+                                      FLAGS_eloq_store_cloud_store_path);
+    eloq_store_config.gc_threads_ =
+        !eloq_store_config.cloud_store_path_.empty()
+            ? 0
+            : (!CheckCommandLineFlagIsDefault("eloq_store_gc_threads")
+                   ? FLAGS_eloq_store_gc_threads
+                   : config_reader.GetInteger("store",
+                                              "eloq_store_gc_threads",
+                                              FLAGS_eloq_store_gc_threads));
+    LOG_IF(INFO, !eloq_store_config.cloud_store_path_.empty())
+        << "EloqStore cloud store enabled";
     auto ds_factory =
         std::make_unique<EloqDS::EloqStoreDataStoreFactory>(eloq_store_config);
 
@@ -384,11 +408,21 @@ int main(int argc, char *argv[])
             .append("/ds_")
             .append(std::to_string(shard_id));
         store_config.fd_limit = eloq_store_config.open_files_limit_;
+        if (!eloq_store_config.cloud_store_path_.empty())
+        {
+            store_config.cloud_store_path
+                .append(eloq_store_config.cloud_store_path_)
+                .append("/ds_")
+                .append(std::to_string(shard_id));
+        }
+        store_config.num_gc_threads = eloq_store_config.gc_threads_;
 
         DLOG(INFO) << "Create EloqStore storage with workers: "
                    << store_config.num_threads
                    << ", store path: " << store_config.store_path.front()
-                   << ", open files limit: " << store_config.fd_limit;
+                   << ", open files limit: " << store_config.fd_limit
+                   << ", cloud store path: " << store_config.cloud_store_path
+                   << ", gc threads: " << store_config.num_gc_threads;
         auto ds = std::make_unique<EloqDS::EloqStoreDataStore>(
             shard_id, data_store_service_.get(), store_config);
 #else


### PR DESCRIPTION
Add configs to enable cloud store for eloqstore.

TODO:
1. Who is responsible for automatically creating buckets?
2. The current cloud implementation performance is too poor, causing RPC operations to always time out.
3. After bootstrap, starting the server fails with the error log:
   ```
   [eloq_store.cpp:186] "/home/cz-studio/datas/eloqsql//eloq_dss/eloqstore/ds_0" is not empty in cloud store mode
   ```
   the related code:
   ```
   if (cloud_store && !std::filesystem::is_empty(store_path))
            {
                LOG(ERROR) << store_path << " is not empty in cloud store mode";
                return KvError::InvalidArgs;
            }
   ```
   Based on the current logic, the server cannot be restarted?