### PR TITLE
Disable auto compaction at the 1st place to make sure purger blocking…

### DIFF
--- a/eloq_data_store_service/purger_sliding_window.cpp
+++ b/eloq_data_store_service/purger_sliding_window.cpp
@@ -128,7 +128,8 @@ void S3FileNumberUpdater::UpdateSmallestFileNumber(uint64_t file_number,
 
 void S3FileNumberUpdater::BlockPurger(const std::string &epoch)
 {
-    DLOG(INFO) << "Wrote 0 as file number to S3 to block purger";
+    DLOG(INFO) << "Wrote 0 as file number to S3 to block purger, epoch: "
+               << epoch;
     UpdateSmallestFileNumber(std::numeric_limits<uint64_t>::min(), epoch);
     // Don't update last_published_smallest_ in sliding window,
     // so that future smaller file number can still be updated

--- a/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -607,6 +607,9 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     options.compaction_filter =
         static_cast<rocksdb::CompactionFilter *>(ttl_compaction_filter_.get());
 
+    // Disable auto compactions before blocking purger
+    options.disable_auto_compactions = true;
+
     auto start = std::chrono::system_clock::now();
     std::unique_lock<std::shared_mutex> db_lk(db_mux_);
     rocksdb::Status status;
@@ -683,6 +686,9 @@ bool RocksDBCloudDataStore::OpenCloudDB(
 
     // Resume background work
     db_->ContinueBackgroundWork();
+
+    // Enable auto compactions after blocking purger
+    status = db_->SetOptions({{"disable_auto_compactions", "false"}});
 
     if (cloud_config_.warm_up_thread_num_ != 0)
     {


### PR DESCRIPTION
… succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup stability by temporarily disabling auto compactions during database open to prevent conflicts with background purging, then re-enabling them after initialization.

* **Chores**
  * Enhanced logging for purging activity by including the epoch value to improve observability and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->