### PR TITLE
Remove purger from eloq_store build

### DIFF
--- a/eloq_data_store_service/build_eloq_store.cmake
+++ b/eloq_data_store_service/build_eloq_store.cmake
@@ -96,9 +96,7 @@ set(ELOQ_STORE_SOURCES
     ${ELOQ_STORE_SOURCE_DIR}/object_store.cpp
     ${ELOQ_STORE_SOURCE_DIR}/types.cpp
     ${ELOQ_STORE_SOURCE_DIR}/kv_options.cpp
-    ${ELOQ_STORE_SOURCE_DIR}/eloqstore_module.cpp
-    ${ELOQ_STORE_SOURCE_DIR}/purger_event_listener.cpp
-    ${ELOQ_STORE_SOURCE_DIR}/purger_sliding_window.cpp)
+    ${ELOQ_STORE_SOURCE_DIR}/eloqstore_module.cpp)
 
 add_library(eloqstore STATIC ${ELOQ_STORE_SOURCES} ${INI_SOURCES})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build configuration to exclude certain purger-related components from the static library, reducing compiled sources and potentially decreasing build time and binary size.
  - No changes to public APIs; existing features outside the excluded purger functionality remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->