### PR TITLE
Start from backup or snapshot cloud-manifest

### DIFF
--- a/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -396,9 +396,12 @@ bool RocksDBCloudDataStore::StartDB()
         LOG(ERROR) << "Failed to find max term from cloud manifest file for "
                       "branch: "
                    << cloud_config_.branch_name_;
+        // this is a new db
+        cookie_on_open = "";
+        new_cookie_on_open = MakeCloudManifestCookie(
+            cloud_config_.branch_name_, dss_shard_id, 0);
     }
-
-    if (max_term != -1)
+    else if (max_term != -1)
     {
         cookie_on_open = MakeCloudManifestCookie(
             cloud_config_.branch_name_, dss_shard_id, max_term);
@@ -407,8 +410,8 @@ bool RocksDBCloudDataStore::StartDB()
     }
     else
     {
-        // this is a new db
-        cookie_on_open = "";
+        // this is snapshot restore case, no valid cloud manifest file
+        cookie_on_open = cloud_config_.branch_name_;
         new_cookie_on_open = MakeCloudManifestCookie(
             cloud_config_.branch_name_, dss_shard_id, 0);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup reliability when the cloud manifest is missing or after a snapshot restore.
  * Ensures correct initialization of session cookies in edge cases to avoid open failures.
  * Adjusted logic to only consider previous terms when a valid manifest is found, preventing incorrect recovery states.
  * Clarified behavior to consistently use the correct branch information during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->