### PR TITLE
Fix txlog open abort

### DIFF
--- a/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -329,9 +329,10 @@ bool RocksDBCloudDataStore::StartDB()
     // Temp fix for very slow open db issue
     // TODO(monkeyzilla): implement customized sst file manager
     cfs_options_.constant_sst_file_size_in_sst_file_manager = 64 * 1024 * 1024L;
-    // Skip listing cloud files in GetChildren when DumpDBSummary to speed
-    // up open db
-    // cfs_options_.skip_cloud_files_in_getchildren = true;
+    // Skip listing cloud files in GetChildren when DumpDBSummary,
+    // SanitizeOptions, Recover(CheckConsistency), WriteOptions to speed up open
+    // db
+    cfs_options_.skip_cloud_files_in_getchildren = true;
 
     DLOG(INFO) << "RocksDBCloudDataStore::StartDB, purger_periodicity_millis: "
                << cfs_options_.purger_periodicity_millis << " ms"
@@ -445,7 +446,10 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     options.create_missing_column_families = true;
     // boost write performance by enabling unordered write
     options.unordered_write = true;
-    // options.paranoid_checks = false;
+    // skip Consistency check, which compares the actual file size with the size
+    // recorded in the metadata, which can fail when skip_cloud_files_in_getchildren is
+    // set to true
+    options.paranoid_checks = false;
 
     // print db statistics every 60 seconds
     if (enable_stats_)


### PR DESCRIPTION
max_open_files could not be -1, otherwise DB will load all files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Temporarily limits resources used during startup to reduce contention and speed opening large databases; skips some heavy consistency checks when safe.

- **Bug Fixes**
  - Adds more comprehensive cleanup on multiple initialization failures to prevent partially started services and resource leaks.

- **Reliability**
  - Restores safer defaults and rollbacks after failed startup steps; improves fail-fast behavior for misconfiguration or background-work errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->