### PR TITLE
Don't save deleted records into data_store if mvcc is not enabled on RangePartition 

### DIFF
--- a/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -702,8 +702,8 @@ void RocksDBDataStoreCommon::ScanNext(ScanRequest *scan_req)
     query_worker_pool_->SubmitWork(
         [this, scan_req]()
         {
-            DLOG(INFO) << "RocksDBDataStoreCommon::ScanNext "
-                       << scan_req->GetPartitionId();
+            // DLOG(INFO) << "RocksDBDataStoreCommon::ScanNext "
+            //            << scan_req->GetPartitionId();
             PoolableGuard poolable_guard(scan_req);
 
             uint32_t partition_id = scan_req->GetPartitionId();


### PR DESCRIPTION
Related PR:
https://github.com/eloqdata/eloqsql/pull/136
https://github.com/eloqdata/eloqdoc/pull/231
https://github.com/eloqdata/eloqkv/pull/215



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of range-partitioned deletes when MVCC is disabled, emitting DELETE operations for accurate deletion semantics and potential storage savings.
* **Refactor**
  * Streamlined write batching by removing unnecessary bookkeeping to reduce overhead and improve efficiency.
* **Chores**
  * Suppressed previously verbose debug logging during scan operations to reduce log noise without affecting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->