### PR TITLE
Use "INFO" level to print "key not found" log  in `SyncBatchReadForArchiveCallback`

### DIFF
--- a/data_store_service_client_closure.cpp
+++ b/data_store_service_client_closure.cpp
@@ -65,11 +65,8 @@ void SyncBatchReadForArchiveCallback(void *data,
     auto err_code = result.error_code();
     if (err_code == remote::DataStoreError::KEY_NOT_FOUND)
     {
-        LOG(ERROR) << "BatchReadForArchiveCallback, key not found: "
-                   << read_closure->Key();
-        // callback_data->SetErrorCode(
-        //     static_cast<int>(txservice::CcErrorCode::DATA_STORE_ERR));
-        // assert(false);
+        LOG(INFO) << "BatchReadForArchiveCallback, key not found: "
+                  << read_closure->Key() << " , set as deleted";
         std::string_view key_str = read_closure->Key();
         uint64_t ts = 1U;
         uint64_t ttl = 0U;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of archive data retrieval operations. Missing entries are now handled gracefully by treating them as deleted entries within the batch read process, rather than triggering error conditions, enabling more reliable access to archived data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->