### PR TITLE
introduce enable_compression parameter

### DIFF
--- a/eloq_data_store_service/eloq_store_config.cpp
+++ b/eloq_data_store_service/eloq_store_config.cpp
@@ -99,6 +99,9 @@ DEFINE_uint32(eloq_store_pages_per_file_shift,
               "EloqStore pages per file shift.");
 DEFINE_uint32(eloq_store_overflow_pointers, 16, "EloqStore overflow pointers.");
 DEFINE_bool(eloq_store_data_append_mode, false, "EloqStore data append mode.");
+DEFINE_bool(eloq_store_enable_compression,
+            false,
+            "EloqStore enable compression.");
 
 namespace EloqDS
 {
@@ -304,6 +307,12 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetBoolean("store",
                                        "eloq_store_data_append_mode",
                                        FLAGS_eloq_store_data_append_mode);
+    eloqstore_configs_.enable_compression =
+        !CheckCommandLineFlagIsDefault("eloq_store_enable_compression")
+            ? FLAGS_eloq_store_enable_compression
+            : config_reader.GetBoolean("store",
+                                       "eloq_store_enable_compression",
+                                       FLAGS_eloq_store_enable_compression);
 }
 
 void EloqStoreConfig::ParseStoragePath(

--- a/eloq_data_store_service/eloq_store_data_store.h
+++ b/eloq_data_store_service/eloq_store_data_store.h
@@ -164,7 +164,7 @@ class EloqStoreDataStore : public DataStore
 public:
     EloqStoreDataStore(uint32_t shard_id, DataStoreService *data_store_service);
 
-    ~EloqStoreDataStore() = default;
+    ~EloqStoreDataStore() override = default;
 
     bool Initialize() override
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compression configuration option for EloqStore, enabling users to control compression behavior via command-line or configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->