### PR TITLE
remove duplicated index_buffer_pool_size calculation

### DIFF
--- a/eloq_data_store_service/eloq_store_config.cpp
+++ b/eloq_data_store_service/eloq_store_config.cpp
@@ -208,7 +208,6 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetInteger("store",
                                        "eloq_store_index_buffer_pool_size",
                                        FLAGS_eloq_store_index_buffer_pool_size);
-    eloqstore_configs_.index_buffer_pool_size /= eloqstore_configs_.num_threads;
     eloqstore_configs_.manifest_limit =
         !CheckCommandLineFlagIsDefault("eloq_store_manifest_limit")
             ? FLAGS_eloq_store_manifest_limit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified index buffer pool size calculation to apply configured values directly without thread-count scaling, resulting in adjusted memory allocation for indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->