### PR TITLE
call Clear() of batchwriterequest after flushing

### DIFF
--- a/eloq_data_store_service/eloq_store_data_store.cpp
+++ b/eloq_data_store_service/eloq_store_data_store.cpp
@@ -256,6 +256,7 @@ void EloqStoreDataStore::OnBatchWrite(::eloqstore::KvRequest *req)
 
         result.set_error_code(::EloqDS::remote::DataStoreError::WRITE_FAILED);
         result.set_error_msg(write_req->ErrMessage());
+        write_req->Clear();
         ds_write_req->SetFinish(result);
         return;
     }


### PR DESCRIPTION
clear BatchWriteRequest's data vector after flushing to release memory in time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal resource cleanup in the data store service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->