### PR TITLE
no-op if dss has non shard

### DIFF
--- a/eloq_data_store_service/data_store_service.cpp
+++ b/eloq_data_store_service/data_store_service.cpp
@@ -1815,7 +1815,7 @@ void DataStoreService::CloseDataStore(uint32_t shard_id)
 {
     if (shard_id_ == UINT32_MAX)
     {
-        DLOG(INFO) << "CloseDataStore no-op for non-owner DSS"
+        DLOG(INFO) << "CloseDataStore no-op for DSS has no shard assigned"
                    << ", shard " << shard_id
                    << ", shard_id_: " << shard_id_;
         return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safety checks to data store operations to handle edge cases where no shard is properly assigned, preventing potential system errors and improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->