### PR TITLE
Fix 2 bugs

### DIFF
--- a/eloq_data_store_service/data_store_service.cpp
+++ b/eloq_data_store_service/data_store_service.cpp
@@ -2292,6 +2292,7 @@ bool DataStoreService::SwitchReadOnlyToClosed(uint32_t shard_id)
     {
         cluster_manager_.SwitchShardToClosed(shard_id, expected);
         data_store_->Shutdown();
+        data_store_ = nullptr;
     }
     return true;
 }


### PR DESCRIPTION
1. copybasetoarchive read err code is ignored
2. data store close didnot reset pointer to null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust archive operations: reads now complete before error aggregation and reporting, reducing premature failures during bulk copy.
  * Safer shutdown behavior: internal data references are cleared after shutdown to prevent potential post-shutdown access issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->