### PR TITLE
pass missed ttl in eloq_store_data_store

### DIFF
--- a/eloq_data_store_service/eloq_store_data_store.cpp
+++ b/eloq_data_store_service/eloq_store_data_store.cpp
@@ -200,6 +200,8 @@ void EloqStoreDataStore::BatchWriteRecords(WriteRecordsRequest *write_req)
         entry.op_ = (write_req->KeyOpType(i) == WriteOpType::PUT
                          ? ::eloqstore::WriteOp::Upsert
                          : ::eloqstore::WriteOp::Delete);
+        uint64_t ttl = write_req->GetRecordTtl(i);
+        entry.expire_ts_ = ttl == UINT64_MAX ? 0 : ttl;
         entries.emplace_back(std::move(entry));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-record time-to-live (TTL) support in batch write operations, enabling automatic expiration of individual records during batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->