### PR TITLE
Add disable write stall parameter

### DIFF
--- a/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -596,6 +596,11 @@ bool RocksDBCloudDataStore::OpenCloudDB(
             max_bytes_for_level_multiplier_;
     }
 
+    if (disable_write_stall_)
+    {
+        options.disable_write_stall = disable_write_stall_;
+    }
+
     // Add event listener for purger
     rocksdb::CloudFileSystemImpl *cfs_impl =
         dynamic_cast<rocksdb::CloudFileSystemImpl *>(cloud_fs_.get());

--- a/eloq_data_store_service/rocksdb_config.cpp
+++ b/eloq_data_store_service/rocksdb_config.cpp
@@ -98,6 +98,10 @@ DEFINE_string(
     rocksdb_batch_write_size,
     "1MB", /*Adjust for balancing the memory footprint and throughput*/
     "RocksDB batch write size when doing checkpoint");
+DEFINE_bool(
+    rocksdb_disable_write_stall,
+    false,
+    "RocksDB disable write stall due to too many background operations");
 
 DEFINE_uint32(
     rocksdb_periodic_compaction_seconds,
@@ -489,6 +493,12 @@ RocksDBConfig::RocksDBConfig(const INIReader &config,
             : config.GetString("store",
                                "rocksdb_dialy_offpeak_time_utc",
                                FLAGS_rocksdb_dialy_offpeak_time_utc);
+    disable_write_stall_ =
+        !CheckCommandLineFlagIsDefault("rocksdb_disable_write_stall")
+            ? FLAGS_rocksdb_disable_write_stall
+            : config.GetBoolean("store",
+                                "rocksdb_disable_write_stall",
+                                FLAGS_rocksdb_disable_write_stall);
 };
 
 #if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) ||                      \

--- a/eloq_data_store_service/rocksdb_config.h
+++ b/eloq_data_store_service/rocksdb_config.h
@@ -66,6 +66,7 @@ struct RocksDBConfig
     size_t batch_write_size_;
     size_t periodic_compaction_seconds_;
     std::string dialy_offpeak_time_utc_;
+    bool disable_write_stall_;
 };
 
 #if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) ||                      \

--- a/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/eloq_data_store_service/rocksdb_data_store_common.h
@@ -141,6 +141,7 @@ public:
               config.hard_pending_compaction_bytes_limit_bytes_),
           max_subcompactions_(config.max_subcompactions_),
           write_rate_limit_(config.write_rate_limit_bytes_),
+          disable_write_stall_(config.disable_write_stall_),
           batch_write_size_(config.batch_write_size_),
           periodic_compaction_seconds_(config.periodic_compaction_seconds_),
           dialy_offpeak_time_utc_(config.dialy_offpeak_time_utc_),
@@ -307,6 +308,7 @@ protected:
     const size_t hard_pending_compaction_bytes_limit_;
     const size_t max_subcompactions_;
     const size_t write_rate_limit_;
+    const bool disable_write_stall_;
     const size_t batch_write_size_;
     const size_t periodic_compaction_seconds_;
     const std::string dialy_offpeak_time_utc_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rocksdb_disable_write_stall configuration option, enabling users to control RocksDB write stall behavior for improved database performance and throughput optimization during peak workloads. This new setting is fully configurable via command-line arguments or INI configuration files, and defaults to disabled for maximum backward compatibility with existing system configurations and deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->