### PR TITLE
put slices in different ranges into a single batch write

### DIFF
--- a/data_store_service_client.h
+++ b/data_store_service_client.h
@@ -596,7 +596,7 @@ private:
     void DispatchRangeSliceBatches(std::string_view kv_table_name,
                                    int32_t kv_partition_id,
                                    uint64_t version,
-                                   const RangeSliceBatchPlan &plan,
+                                   const std::vector<RangeSliceBatchPlan> &plans,
                                    SyncConcurrentRequest *sync_concurrent);
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Cross-plan batching for range-slice writes: segments from multiple plans are merged into larger batched writes, reducing RPC calls and improving throughput and latency.
* **Behavior**
  * Write dispatch now sends larger, consolidated batches with per-batch concurrency control, decreasing overhead for multi-range updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->