### PR TITLE
Refactor the eloqstore data dir.

### DIFF
--- a/eloq_data_store_service/eloq_store_data_store.cpp
+++ b/eloq_data_store_service/eloq_store_data_store.cpp
@@ -79,14 +79,14 @@ EloqStoreDataStore::EloqStoreDataStore(uint32_t shard_id,
     ::eloqstore::KvOptions opts =
         factory->eloq_store_configs_.eloqstore_configs_;
     // Fix storage path
-    for (auto &path : opts.store_path)
-    {
-        path.append("/ds_").append(std::to_string(shard_id));
-    }
-    if (!opts.cloud_store_path.empty())
-    {
-        opts.cloud_store_path.append("/ds_").append(std::to_string(shard_id));
-    }
+    // for (auto &path : opts.store_path)
+    // {
+    //     path.append("/ds_").append(std::to_string(shard_id));
+    // }
+    // if (!opts.cloud_store_path.empty())
+    // {
+    //     opts.cloud_store_path.append("/ds_").append(std::to_string(shard_id));
+    // }
 
     DLOG(INFO) << "Create EloqStore storage with workers: " << opts.num_threads
                << ", store path: " << opts.store_path.front()


### PR DESCRIPTION
For EloqStore, the data dir in local or remote are as follows:
```
data/{table}.{partition_id}
```

instead of 
```
data/ds_{shard_id}/{table}.{partition_id}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage path handling by removing automatic path modifications during initialization. Storage locations are now used exactly as configured without automatic augmentation, ensuring predictable behavior consistent with your configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->